### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v1
       - name: Build and push Docker image
-        uses: elgohr/Publish-Docker-Github-Action@2.19
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: c2d7fa/timespectre
           username: ${{secrets.docker_username}}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore